### PR TITLE
Transformed io:format in logger calls

### DIFF
--- a/src/dds_data_w.erl
+++ b/src/dds_data_w.erl
@@ -65,7 +65,7 @@ handle_call({is_sample_acknowledged, ChangeKey}, _, #state{rtps_writer = W} = S)
     {reply, rtps_full_writer:is_acked_by_all(W,ChangeKey), S};
 handle_call(wait_for_acknoledgements, _, #state{rtps_writer = _W} = S) ->
     % not implemented
-    io:format("DDS_DATA_W: wait_for_acknoledgements Not implemented\n"),
+    logger:warning("DDS_DATA_W: wait_for_acknoledgements Not implemented\n"),
     {reply, ok, S};
 handle_call(flush_all_changes, _, #state{rtps_writer = W} = S) ->
     rtps_full_writer:flush_all_changes(W),

--- a/src/rtps_gateway.erl
+++ b/src/rtps_gateway.erl
@@ -34,8 +34,8 @@ handle_cast({send, {Datagram, Dst}}, #state{socket = S} = State) ->
     case gen_udp:send(S, Dst, Datagram) of
         ok -> ok;
         {error, Reason} -> 
-                        io:format("[GATEWAY]: failed sending to: ~p\n",[Dst]),
-                        io:format("[GATEWAY]: reason of failure: ~p\n",[Reason])
+                        logger:error("[GATEWAY]: failed sending to: ~p\n",[Dst]),
+                        logger:error("[GATEWAY]: reason of failure: ~p\n",[Reason])
     end,
     {noreply, State};
 handle_cast(_, State) ->

--- a/src/rtps_receiver.erl
+++ b/src/rtps_receiver.erl
@@ -317,7 +317,7 @@ handle_info({udp, _Socket, Ip, Port, Packet}, #state{openedSockets = OS} = S) ->
         true ->
             analize(S#state.destGuidPrefix, Packet, {Ip, Port});
         false ->
-            io:format("[RTPS_RECEIVER]: Bad packet\n")
+            logger:error("[RTPS_RECEIVER]: Bad packet")
     end,
     {noreply, S}.
 


### PR DESCRIPTION
To use a more consistent displaying of errors I changed `io:format` calls into `logger` calls